### PR TITLE
Fix tests for changes to psr7 guzzle

### DIFF
--- a/tests/Message/CaptureResponseTest.php
+++ b/tests/Message/CaptureResponseTest.php
@@ -9,7 +9,7 @@ class CaptureResponseTest extends TestCase
     public function testCaptureSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CaptureSuccess.txt');
-        $response = new CaptureResponse($this->getMockRequest(), $httpResponse->json());
+        $response = new CaptureResponse($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -20,7 +20,7 @@ class CaptureResponseTest extends TestCase
     public function testCaptureFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CaptureFailure.txt');
-        $response = new CaptureResponse($this->getMockRequest(), $httpResponse->json());
+        $response = new CaptureResponse($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -9,7 +9,7 @@ class ResponseTest extends TestCase
     public function testPurchaseSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('PurchaseSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -20,7 +20,7 @@ class ResponseTest extends TestCase
     public function testPurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('PurchaseFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -31,7 +31,7 @@ class ResponseTest extends TestCase
     public function testCardSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CardSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -42,7 +42,7 @@ class ResponseTest extends TestCase
     public function testCardFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CardFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -53,7 +53,7 @@ class ResponseTest extends TestCase
     public function testCustomerSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CustomerSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -64,7 +64,7 @@ class ResponseTest extends TestCase
     public function testCustomerFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CustomerFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->json());
+        $response = new Response($this->getMockRequest(), json_decode($httpResponse->getBody(), true));
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());


### PR DESCRIPTION
Guzzle version has dropped the ->json() method.  Need to json decode
the response body instead.

Assuming you are having troubles with the tests, this might be the fix.