### PR TITLE
Build http query string instead of json encoding

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -131,11 +131,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         );*/
 
         // Return the response we get back from Pin Payments
-        return $this->httpClient->request(
-            $method,
-            $this->getEndpoint() . $action,
-            array('Authorization' => 'Basic ' . base64_encode($this->getSecretKey() . ':')),
-            json_encode($data)
-        );
+        $url = $this->getEndpoint() . $action;
+        $headers = array('Authorization' => 'Basic ' . base64_encode($this->getSecretKey() . ':'));
+        $body = $data ? http_build_query($data, '', '&') : null;
+        return $this->httpClient->request($method, $url, $headers, $body);
     }
 }


### PR DESCRIPTION
JSON encoding is messing up the parameters, it needs a params string instead.

**Refs:**
https://github.com/guzzle/guzzle/issues/1079
https://github.com/thephpleague/omnipay-stripe/commit/4e475ace6c9e8626df41c5a6c1fd88e95c4ba759#diff-f1a888a4f0baadb508b5a2bd87ed09c6R197